### PR TITLE
Add Wagtail, minimum setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ pip install django~=1.11.0
 python manage.py migrate
 python manage.py runserver
 ```
+
+## Beyond Django, Wagtail
+
+http://docs.wagtail.io/en/v2.0.1/getting_started/integrating_into_django.html
+
+```sh
+source myvenv/bin/activate
+pip install wagtail~=2.0.0
+python manage.py migrate
+python manage.py runserver
+```

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -38,6 +38,21 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'blog',
+
+    'wagtail.contrib.forms',
+    'wagtail.contrib.redirects',
+    'wagtail.embeds',
+    'wagtail.sites',
+    'wagtail.users',
+    'wagtail.snippets',
+    'wagtail.documents',
+    'wagtail.images',
+    'wagtail.search',
+    'wagtail.admin',
+    'wagtail.core',
+
+    'modelcluster',
+    'taggit',
 ]
 
 MIDDLEWARE = [
@@ -48,6 +63,9 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'wagtail.core.middleware.SiteMiddleware',
+    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 
 ROOT_URLCONF = 'mysite.urls'
@@ -120,3 +138,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+WAGTAIL_SITE_NAME = 'Django Girls, Wagtail edition'

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -1,8 +1,17 @@
-from django.conf.urls import include
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib import admin
+from django.conf import settings
+from django.conf.urls.static import static
+
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.documents import urls as wagtaildocs_urls
+from wagtail.core import urls as wagtail_urls
+
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'^cms/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^pages/', include(wagtail_urls)),
     url(r'', include('blog.urls')),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This follows http://docs.wagtail.io/en/v2.0.1/getting_started/integrating_into_django.html to add the base setup for Wagtail inside the existing Django Girls project.

It does not do anything with Wagtail (yet!).